### PR TITLE
Added check for fields filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4.1"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/BrainsoftLtd/loopback-ds-computed-mixin.svg?branch=master)](https://travis-ci.org/BrainsoftLtd/loopback-ds-computed-mixin)
+
 COMPUTED MIXIN
 =============
 

--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ function computed(Model, options) {
   debug('Computed mixin for Model %s with options %o', Model.modelName, options);
 
   Model.observe('access', function logQuery(ctx, next) {
-    
+
       // We store the fields filter, if any, to check it later in the loaded observer      
       ctx.options.computedInfo = {};
       ctx.options.computedInfo.hasFieldFilter = !_.isUndefined(ctx.query.fields);
       if (ctx.options.computedInfo.hasFieldFilter) ctx.options.computedInfo.fieldList = ctx.query.fields;
-    
+
     next();
   });
 
@@ -56,7 +56,7 @@ function computed(Model, options) {
           debug('Field %s not included in field filter', property);
           return false;
       }
-      
+
       debug('Computing property %s with callback %s', property, callback);
 
       var value = Model[callback](ctx.instance);

--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ function computed(Model, options) {
 
   Model.observe('access', function logQuery(ctx, next) {
 
-      // We store the fields filter, if any, to check it later in the loaded observer      
-      ctx.options.computedInfo = {};
-      ctx.options.computedInfo.hasFieldFilter = !_.isUndefined(ctx.query.fields);
-      if (ctx.options.computedInfo.hasFieldFilter) ctx.options.computedInfo.fieldList = ctx.query.fields;
+    // We store the fields filter, if any, to check it later in the loaded observer
+    ctx.options.computedInfo = {};
+    ctx.options.computedInfo.hasFieldFilter = !_.isUndefined(ctx.query.fields);
+    if (ctx.options.computedInfo.hasFieldFilter) ctx.options.computedInfo.fieldList = ctx.query.fields;
 
     next();
   });
@@ -53,8 +53,8 @@ function computed(Model, options) {
 
       // If the query includes a field filter, we do not continue if the field was not specified
       if (ctx.options.computedInfo.hasFieldFilter && ctx.options.computedInfo.fieldList.indexOf(property) == -1) {
-          debug('Field %s not included in field filter', property);
-          return false;
+        debug('Field %s not included in field filter', property);
+        return false;
       }
 
       debug('Computing property %s with callback %s', property, callback);

--- a/index.js
+++ b/index.js
@@ -26,6 +26,16 @@ function computed(Model, options) {
 
   debug('Computed mixin for Model %s with options %o', Model.modelName, options);
 
+  Model.observe('access', function logQuery(ctx, next) {
+    
+      // We store the fields filter, if any, to check it later in the loaded observer      
+      ctx.options.computedInfo = {};
+      ctx.options.computedInfo.hasFieldFilter = !_.isUndefined(ctx.query.fields);
+      if (ctx.options.computedInfo.hasFieldFilter) ctx.options.computedInfo.fieldList = ctx.query.fields;
+    
+    next();
+  });
+
   // The loaded observer is triggered when an item is loaded
   Model.observe('loaded', function(ctx, next) {
     // We don't act on new instances
@@ -41,6 +51,12 @@ function computed(Model, options) {
         return false;
       }
 
+      // If the query includes a field filter, we do not continue if the field was not specified
+      if (ctx.options.computedInfo.hasFieldFilter && ctx.options.computedInfo.fieldList.indexOf(property) == -1) {
+          debug('Field %s not included in field filter', property);
+          return false;
+      }
+      
       debug('Computing property %s with callback %s', property, callback);
 
       var value = Model[callback](ctx.instance);


### PR DESCRIPTION
The original implementation ignores the fields filter, and always includes all computed properties in the output. This is functionally incorrect, and a possible performance penalty.

I have tested this for the 'normal' fields filter, I have not tested this for scopes.
