### PR TITLE
Fix issue with computed property method called twice (if it returns Promise)

### DIFF
--- a/lib/computed.js
+++ b/lib/computed.js
@@ -36,16 +36,13 @@ module.exports = function(Model, options) {
 
       debug('Computing property %s with callback %s', property, callback);
 
-      var value = Model[callback](ctx.instance);
-      if (value.then === undefined) {
-        ctx.instance[property] = value;
-      } else {
-        return Model[callback](ctx.instance)
-          .then(function(res) {
-            ctx.instance[property] = res;
-          })
-          .catch(next);
-      }
+      //`Promise.resolve` will normalize promises and raw values
+      return Promise
+        .resolve(Model[callback](ctx.instance))
+        .then(function(value) {
+          ctx.instance[property] = value;
+        });
+
     }).then(function() {
       next();
     }).catch(next);


### PR DESCRIPTION
1) Computed property method `Model[callback](ctx.instance)` called twice if it returns Promise.
To avoid this behavior I have used `Promise.resolve`. It normalizes Promises and non-Promises.
See http://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise
2) It also fixes the issue when computed property returns with `then` (e.g. `{then:true}`) but not actually the Promise.