### PR TITLE
Enable to access current context from within callback method

### DIFF
--- a/lib/computed.js
+++ b/lib/computed.js
@@ -38,7 +38,7 @@ module.exports = (Model, options) => {
 
       // `Promise.resolve` will normalize promises and raw values
       return Promise
-        .resolve(Model[callback](ctx.data))
+        .resolve(Model[callback](ctx.data, ctx.options))
         .then(value => (ctx.data[property] = value))
     })
   })


### PR DESCRIPTION
Support new solution for context propergation as described below.
https://loopback.io/doc/en/lb3/Using-current-context.html#write-a-custom-remote-method-with-options
https://strongloop.com/strongblog/context-propagation-in-loopback/