### PR TITLE
can skip computed properties calculation to prevent recursion problems

### DIFF
--- a/lib/computed.js
+++ b/lib/computed.js
@@ -26,6 +26,11 @@ module.exports = (Model, options) => {
       return next()
     }
 
+    // Skip if specified in options
+    if (ctx.options.skipComputed) {
+      return next()
+    }
+
     return Promise.map(Object.keys(options.properties), property => {
       const callback = options.properties[property]
 

--- a/test/test.js
+++ b/test/test.js
@@ -106,4 +106,15 @@ describe('loopback computed property', function() {
         expect(itemFromDb).to.not.have.property('promised')
       })
   })
+
+  it('should not compute if requested with "skipComputed" attribute', function() {
+    const { id } = this.itemOne
+
+    return new Promise(function(res) {
+      Item.find({ where: { id } }, { skipComputed: true }).then(function(item) {
+        expect(typeof item[0].readonly).to.be.equal('undefined')
+        res()
+      })
+    })
+  })
 })


### PR DESCRIPTION
When retrieving related models of same type in the computed property, we get to the unlimited recursion which is hard to avoid without ugly hack. I added property to be able to stop computed properties being computed